### PR TITLE
feat: add request API that returns pyarrow arrays instead of python objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ dependencies = [
  "ark-std 0.4.0",
  "derivative",
  "digest 0.10.7",
- "itertools",
+ "itertools 0.10.5",
  "num-bigint",
  "num-traits",
  "paste",
@@ -1317,6 +1317,7 @@ dependencies = [
  "arrow2",
  "dict_derive",
  "env_logger",
+ "itertools 0.12.1",
  "prefix-hex",
  "pyo3",
  "pyo3-asyncio",
@@ -1395,6 +1396,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ anyhow = "1"
 arrow2 = { version = "0.18" }
 prefix-hex = "0.7.1"
 env_logger = "0.11"
+itertools = "0.12.1"

--- a/examples/top-usdt.py
+++ b/examples/top-usdt.py
@@ -46,6 +46,7 @@ async def collect_events():
     await client.create_parquet_folder(query, config)
 
 def analyze_events():
+# create polars dataframe from arrow instead of read_parquet
     logs = polars.read_parquet(
         "data/logs.parquet",
     )

--- a/examples/top-usdt.py
+++ b/examples/top-usdt.py
@@ -46,7 +46,6 @@ async def collect_events():
     await client.create_parquet_folder(query, config)
 
 def analyze_events():
-# create polars dataframe from arrow instead of read_parquet
     logs = polars.read_parquet(
         "data/logs.parquet",
     )

--- a/hypersync/__init__.py
+++ b/hypersync/__init__.py
@@ -190,3 +190,6 @@ class HypersyncClient:
 
     async def send_events_req(self, query: Query) -> any:
         return await self.inner.send_events_req(asdict(query))
+
+    async def send_arrow_req(self, query: Query) -> any:
+        return await self.inner.send_arrow_req(asdict(query))

--- a/hypersync/__init__.py
+++ b/hypersync/__init__.py
@@ -191,5 +191,5 @@ class HypersyncClient:
     async def send_events_req(self, query: Query) -> any:
         return await self.inner.send_events_req(asdict(query))
 
-    async def send_arrow_req(self, query: Query) -> any:
-        return await self.inner.send_arrow_req(asdict(query))
+    async def send_req_arrow(self, query: Query) -> any:
+        return await self.inner.send_req_arrow(asdict(query))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,6 +242,8 @@ pub struct QueryArrowResponse {
 
 #[pymethods]
 impl QueryArrowResponse {
+    /// TODO: if we want to implement this method we could call _is_initialized method,
+    /// but we will need py reference
     fn __bool__(&self) -> bool {
         true
     }
@@ -311,6 +313,7 @@ impl QueryResponseArrow {
         self.archive_height.is_some()
             || self.next_block != i64::default()
             || self.total_execution_time != i64::default()
+            || self.data.__bool__()
     }
 
     fn __repr__(&self) -> PyResult<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,6 +494,11 @@ fn convert_batch_to_pyarrow_table<'py>(
     pyarrow: &'py PyModule,
     batches: Vec<ArrowBatch>,
 ) -> PyResult<PyObject> {
+
+    if batches.is_empty() {
+        return Ok(py.None());
+    }
+
     let schema = batches.first().unwrap().schema.fields.clone();
     let field = Field::new("a", DataType::Struct(schema), true);
 

--- a/test.py
+++ b/test.py
@@ -114,6 +114,18 @@ async def test_send_req():
     print(f"send_req time: {format(execution_time, '.9f')}ms")
 
 
+async def test_send_req_arrow():
+    client = hypersync.HypersyncClient()
+    total_time = 0
+    for _ in range(NUM_BENCHMARK_RUNS):
+        start_time = time.time()
+        res = await client.send_req_arrow(QUERY)
+        execution_time = (time.time() - start_time) * 1000
+        total_time += execution_time
+    avg_time = total_time / NUM_BENCHMARK_RUNS
+    print(f"send_req_arrow time: {format(execution_time, '.9f')}ms")
+
+
 async def test_send_events_req():
     client = hypersync.HypersyncClient()
     total_time = 0
@@ -180,6 +192,7 @@ async def main():
     print("hypersync-client-python")
     print(f"number of runs for each test: {NUM_BENCHMARK_RUNS}")
     await test_send_req()
+    await test_send_req_arrow()
     await test_send_events_req()
     await test_get_height()
     await test_decode_logs()

--- a/test.py
+++ b/test.py
@@ -116,11 +116,18 @@ async def test_send_req():
 
 async def test_send_req_arrow():
     client = hypersync.HypersyncClient()
+    import pyarrow
     total_time = 0
     for _ in range(NUM_BENCHMARK_RUNS):
         start_time = time.time()
         res = await client.send_req_arrow(QUERY)
         execution_time = (time.time() - start_time) * 1000
+        assert(type(res.data.blocks) == pyarrow.lib.Table)
+        assert(res.data.blocks._is_initialized())
+        assert(type(res.data.transactions) == pyarrow.lib.Table)
+        assert(res.data.transactions._is_initialized())
+        assert(type(res.data.logs) == pyarrow.lib.Table)
+        assert(res.data.logs._is_initialized())
         total_time += execution_time
     avg_time = total_time / NUM_BENCHMARK_RUNS
     print(f"send_req_arrow time: {format(execution_time, '.9f')}ms")


### PR DESCRIPTION
Returns blocks, transactions, and logs in pyarrow.Table format
Have problem with deadlock in with_git call