### PR TITLE
Preset query examples

### DIFF
--- a/examples/simple-blocks-and-transaction-hashes.py
+++ b/examples/simple-blocks-and-transaction-hashes.py
@@ -1,13 +1,13 @@
 import hypersync
 import asyncio
 
-# returns all block and transaction objects within a block range
+# returns all blocks and the hashes of the transactions (not entire transaction objects) within a block range
 
 async def main():
     # Create hypersync client using the mainnet hypersync endpoint (default)
     client = hypersync.HypersyncClient()
 
-    query = client.preset_query_blocks_and_transactions(17_000_000, 17_000_050)
+    query = client.preset_query_blocks_and_transaction_hashes(17_000_000, 17_000_050)
 
     print("Running the query...")
 
@@ -16,7 +16,7 @@ async def main():
     # res.next_block is equal to res.archive_height or query.to_block in case we specified an end block.
     res = await client.send_req(query)
 
-    print(f"Query returned {len(res.data.blocks)} blocks and {len(res.data.transactions)} transactions")
+    print(f"Query returned {len(res.data.blocks)} blocks and {len(res.data.transactions)} transaction hashes")
 
 
 

--- a/examples/simple-blocks-and-transactions.py
+++ b/examples/simple-blocks-and-transactions.py
@@ -1,0 +1,21 @@
+import hypersync
+import asyncio
+
+async def main():
+    # Create hypersync client using the mainnet hypersync endpoint (default)
+    client = hypersync.HypersyncClient()
+
+    query = client.preset_query_blocks_and_transactions(17_000_000, 17_000_050)
+
+    print("Running the query...")
+
+    # Run the query once, the query is automatically paginated so it will return when it reaches some limit (time, response size etc.)
+    # there is a next_block field on the response object so we can set the from_block of our query to this value and continue our query until
+    # res.next_block is equal to res.archive_height or query.to_block in case we specified an end block.
+    res = await client.send_req(query)
+
+    print(f"Query returned {len(res.data.blocks)} blocks and {len(res.data.transactions)} transactions")
+
+
+
+asyncio.run(main())

--- a/examples/simple-logs-of-event.py
+++ b/examples/simple-logs-of-event.py
@@ -1,0 +1,29 @@
+import hypersync
+import asyncio
+
+# returns all logs of a specific event from a contract within a block range
+
+async def main():
+    # Create hypersync client using the mainnet hypersync endpoint (default)
+    client = hypersync.HypersyncClient()
+
+    usdt_contract = "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+
+    # topic0 of transaction event signature (hash of event signature)
+    # query will return logs of this event
+    event_topic_0 = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+
+    query = client.preset_query_logs_of_event(usdt_contract, event_topic_0, 17_000_000, 17_000_050)
+
+    print("Running the query...")
+
+    # Run the query once, the query is automatically paginated so it will return when it reaches some limit (time, response size etc.)
+    # there is a next_block field on the response object so we can set the from_block of our query to this value and continue our query until
+    # res.next_block is equal to res.archive_height or query.to_block in case we specified an end block.
+    res = await client.send_req(query)
+
+    print(f"Query returned {len(res.data.logs)} logs of transfer events from contract {usdt_contract}")
+
+
+
+asyncio.run(main())

--- a/examples/simple-logs.py
+++ b/examples/simple-logs.py
@@ -1,0 +1,25 @@
+import hypersync
+import asyncio
+
+# returns all logs from a contract within a block range
+
+async def main():
+    # Create hypersync client using the mainnet hypersync endpoint (default)
+    client = hypersync.HypersyncClient()
+
+    usdt_contract = "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+
+    query = client.preset_query_logs(usdt_contract, 17_000_000, 17_000_050)
+
+    print("Running the query...")
+
+    # Run the query once, the query is automatically paginated so it will return when it reaches some limit (time, response size etc.)
+    # there is a next_block field on the response object so we can set the from_block of our query to this value and continue our query until
+    # res.next_block is equal to res.archive_height or query.to_block in case we specified an end block.
+    res = await client.send_req(query)
+
+    print(f"Query returned {len(res.data.logs)} logs from contract {usdt_contract}")
+
+
+
+asyncio.run(main())


### PR DESCRIPTION
Added examples for preset query functions in `examples/`
```
simple-blocks-and-transactions/
simple-blocks-and-transaction-hashes/
simple-logs/
simple-logs-of-event/
```