### PR TITLE
docs: Add troubleshooting guide for HyperSync installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ source $HOME/.cargo/env
 
 **Then install hypersync:**
 ```bash
-pip install --no-cache-dir --use-pep517 "hypersync==0.7.17"
+pip install --no-cache-dir --use-pep517 "hypersync==0.8.5"
 ```
 
 Common errors:


### PR DESCRIPTION
Added troubleshooting section for HyperSync installation issues, including installation instructions for Ubuntu/Debian and macOS.

ref: #46 

Don't have the full trace info at the moment, but this is how I fixed this on my ubuntu server as well as mac.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Troubleshooting section to the README with comprehensive guidance on HyperSync installation: environment prerequisites for Ubuntu/Debian and macOS, step-by-step installation instructions, and a catalog of common errors with recommended fixes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->