### PR TITLE
Upgrade PyO3 0.23→0.26 for Python 3.14 support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
           - runner: ubuntu-latest
             target: aarch64
             python-architecture: arm64
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -62,7 +62,7 @@ jobs:
             target: x64
           - runner: windows-latest
             target: x86
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -93,7 +93,7 @@ jobs:
           - runner: macos-14
             target: aarch64
             python-architecture: arm64
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "parity-scale-codec"
@@ -2247,12 +2247,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
  "anyhow",
- "cfg-if",
  "indoc",
  "libc",
  "memoffset",
@@ -2267,9 +2266,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977dc837525cfd22919ba6a831413854beb7c99a256c03bf8624ad707e45810e"
+checksum = "e6ee6d4cb3e8d5b925f5cdb38da183e0ff18122eb2048d4041c9e7034d026e23"
 dependencies = [
  "futures",
  "once_cell",
@@ -2280,19 +2279,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2300,9 +2298,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2312,9 +2310,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3060,9 +3058,9 @@ checksum = "c1bbb9f3c5c463a01705937a24fdabc5047929ac764b2d5b9cf681c1f5041ed5"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ name = "hypersync"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.23", features = [
+pyo3 = { version = "0.26", features = [
   "extension-module",
   "anyhow",
   "num-bigint",
 ] }
-pyo3-async-runtimes = { version = "0.23", features = ["tokio-runtime"] }
+pyo3-async-runtimes = { version = "0.26", features = ["tokio-runtime"] }
 tokio = "1"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Development Status :: 3 - Alpha",
   "Topic :: Database :: Front-Ends",
   "Topic :: Software Development :: Libraries",

--- a/src/arrow_ffi.rs
+++ b/src/arrow_ffi.rs
@@ -8,7 +8,7 @@ use polars_arrow::{
 use pyo3::{
     ffi::Py_uintptr_t,
     types::{PyAnyMethods, PyModule},
-    PyErr, PyObject, Python,
+    Py, PyAny, PyErr, Python,
 };
 
 use crate::{
@@ -17,7 +17,7 @@ use crate::{
 };
 
 pub fn response_to_pyarrow(response: hypersync_client::ArrowResponse) -> Result<ArrowResponse> {
-    let data = Python::with_gil(|py| {
+    let data = Python::attach(|py| {
         let pyarrow = py.import("pyarrow")?;
         Ok::<_, PyErr>(ArrowResponseData {
             blocks: convert_batches_to_pyarrow_table(py, &pyarrow, response.data.blocks)?,
@@ -52,7 +52,7 @@ fn convert_batches_to_pyarrow_table<'py>(
     py: Python<'py>,
     pyarrow: &pyo3::Bound<'py, PyModule>,
     batches: Vec<ArrowBatch>,
-) -> Result<PyObject> {
+) -> Result<Py<PyAny>> {
     if batches.is_empty() {
         return Ok(py.None());
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -43,7 +43,7 @@ impl Decoder {
 
         future_into_py(py, async move {
             Ok(tokio::task::spawn_blocking(move || {
-                Python::with_gil(|py| decoder.decode_logs_sync(logs, py))
+                Python::attach(|py| decoder.decode_logs_sync(logs, py))
             })
             .await
             .unwrap())
@@ -65,7 +65,7 @@ impl Decoder {
 
         future_into_py(py, async move {
             Ok(tokio::task::spawn_blocking(move || {
-                Python::with_gil(|py| decoder.decode_events_sync(events, py))
+                Python::attach(|py| decoder.decode_events_sync(events, py))
             })
             .await
             .unwrap())

--- a/src/decode_call.rs
+++ b/src/decode_call.rs
@@ -43,7 +43,7 @@ impl CallDecoder {
 
         future_into_py(py, async move {
             let result = tokio::task::spawn_blocking(move || {
-                Python::with_gil(|py| decoder.decode_inputs_sync(input, py))
+                Python::attach(|py| decoder.decode_inputs_sync(input, py))
             })
             .await
             .unwrap();
@@ -60,7 +60,7 @@ impl CallDecoder {
 
         future_into_py(py, async move {
             let result = tokio::task::spawn_blocking(move || {
-                Python::with_gil(|py| decoder.decode_transactions_input_sync(txs, py))
+                Python::attach(|py| decoder.decode_transactions_input_sync(txs, py))
             })
             .await
             .unwrap();
@@ -77,7 +77,7 @@ impl CallDecoder {
 
         future_into_py(py, async move {
             let result = tokio::task::spawn_blocking(move || {
-                Python::with_gil(|py| decoder.decode_traces_input_sync(traces, py))
+                Python::attach(|py| decoder.decode_traces_input_sync(traces, py))
             })
             .await
             .unwrap();

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use pyo3::{pyclass, pymethods, Bound, PyAny, PyErr, PyObject, PyResult, Python};
+use pyo3::{pyclass, pymethods, Bound, Py, PyAny, PyErr, PyResult, Python};
 use pyo3_async_runtimes::tokio::future_into_py;
 use tokio::sync::mpsc;
 
@@ -32,16 +32,16 @@ pub struct ArrowResponse {
 #[pyo3(get_all)]
 #[derive(Debug)]
 pub struct ArrowResponseData {
-    pub blocks: PyObject,
-    pub transactions: PyObject,
-    pub logs: PyObject,
-    pub traces: PyObject,
-    pub decoded_logs: PyObject,
+    pub blocks: Py<PyAny>,
+    pub transactions: Py<PyAny>,
+    pub logs: Py<PyAny>,
+    pub traces: Py<PyAny>,
+    pub decoded_logs: Py<PyAny>,
 }
 
 impl Clone for ArrowResponseData {
     fn clone(&self) -> Self {
-        Python::with_gil(|py| Self {
+        Python::attach(|py| Self {
             blocks: self.blocks.clone_ref(py),
             transactions: self.transactions.clone_ref(py),
             logs: self.logs.clone_ref(py),

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,7 @@ use alloy_primitives::{Signed, U256};
 use anyhow::{Context, Result};
 use hypersync_client::{format, format::Hex, net_types, simple_types};
 use num_bigint::{BigInt, BigUint};
-use pyo3::{pyclass, IntoPyObject, PyObject, Python};
+use pyo3::{pyclass, IntoPyObject, Py, PyAny, Python};
 use serde::{Deserialize, Serialize};
 
 /// Data relating to a single event (log)
@@ -208,12 +208,12 @@ pub struct DecodedEvent {
 #[pyclass]
 #[pyo3(get_all)]
 pub struct DecodedSolValue {
-    pub val: PyObject,
+    pub val: Py<PyAny>,
 }
 
 impl Clone for DecodedSolValue {
     fn clone(&self) -> Self {
-        Python::with_gil(|py| Self {
+        Python::attach(|py| Self {
             val: self.val.clone_ref(py),
         })
     }


### PR DESCRIPTION
- Upgrade pyo3 and pyo3-async-runtimes from 0.23 to 0.26
- Migrate deprecated PyObject type alias to Py<PyAny>
- Migrate Python::with_gil to Python::attach
- Add Python 3.14 to CI build matrix and pyproject.toml classifiers
- All deprecation warnings resolved, zero warnings on build

PyO3 0.26 supports Python 3.9 through 3.14, enabling users on the latest Python version to use hypersync.

https://claude.ai/code/session_01KF5pNRVrFDVHaQkCWg8ZJh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Python 3.14 support to CI/CD workflows and project metadata
  * Updated Rust bindings dependencies to latest compatible versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->