### PR TITLE
Add rate limit information and proactive rate limit handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1", features = ["derive"] }
 alloy-json-abi = "1.1"
 alloy-dyn-abi = "1.1"
 alloy-primitives = "1.1"
-hypersync-client = "1.1.1"
+hypersync-client = "1.1.3"
 anyhow = "1"
 arrow = { version = "57", features = ["ffi"] }
 prefix-hex = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync"
-version = "0.11.0"
+version = "1.0.0"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1", features = ["derive"] }
 alloy-json-abi = "1.1"
 alloy-dyn-abi = "1.1"
 alloy-primitives = "1.1"
-hypersync-client = "1.1.0"
+hypersync-client = "1.1.1"
 anyhow = "1"
 arrow = { version = "57", features = ["ffi"] }
 prefix-hex = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1", features = ["derive"] }
 alloy-json-abi = "1.1"
 alloy-dyn-abi = "1.1"
 alloy-primitives = "1.1"
-hypersync-client = "1.1.3"
+hypersync-client = "1.1.4"
 anyhow = "1"
 arrow = { version = "57", features = ["ffi"] }
 prefix-hex = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 
 [lib]
@@ -20,7 +20,7 @@ serde = { version = "1", features = ["derive"] }
 alloy-json-abi = "1.1"
 alloy-dyn-abi = "1.1"
 alloy-primitives = "1.1"
-hypersync-client = "1.0.2"
+hypersync-client = "1.1.0"
 anyhow = "1"
 arrow = { version = "57", features = ["ffi"] }
 prefix-hex = "0.7"

--- a/hypersync/__init__.py
+++ b/hypersync/__init__.py
@@ -5,7 +5,8 @@ from .hypersync import signature_to_topic0 as _sig_to_topic0
 from .hypersync import ArrowStream as _ArrowStream
 from .hypersync import EventStream as _EventStream
 from .hypersync import QueryResponseStream as _QueryResponseStream
-from typing import Optional, Dict
+from .hypersync import RateLimitInfo as _RateLimitInfo
+from typing import Optional, Dict, Tuple
 from dataclasses import dataclass
 from strenum import StrEnum
 
@@ -734,6 +735,9 @@ class ClientConfig:
     retry_ceiling_ms: Optional[int] = None
     # Deprecated: use api_token instead. Will be removed in a future release.
     bearer_token: Optional[str] = None
+    # Whether to proactively sleep when the rate limit is exhausted instead of
+    # sending requests that will be rejected with 429. Default: True.
+    proactive_rate_limit_sleep: Optional[bool] = None
 
 
 class QueryResponseData(object):
@@ -758,6 +762,24 @@ class RollbackGuard(object):
     #
     # This might not be the first scanned block. It only includes blocks that are in memory (possible to be rolled back).
     first_parent_hash: str
+
+
+class RateLimitInfo(object):
+    """Rate limit information from server response headers."""
+    # Total request quota for the current window.
+    limit: Optional[int]
+    # Remaining budget in the current window.
+    remaining: Optional[int]
+    # Seconds until the rate limit window resets.
+    reset_secs: Optional[int]
+    # Budget consumed per request.
+    cost: Optional[int]
+    # Seconds to wait before retrying (from retry-after header).
+    retry_after_secs: Optional[int]
+    # Whether the rate limit quota has been exhausted.
+    is_rate_limited: bool
+    # Suggested number of seconds to wait before making another request.
+    suggested_wait_secs: Optional[int]
 
 
 class QueryResponse(object):
@@ -915,6 +937,18 @@ class HypersyncClient:
     async def get_arrow(self, query: Query) -> ArrowResponse:
         """Executes query with retries and returns the response in Arrow format."""
         return await self.inner.get_arrow(query)
+
+    async def get_with_rate_limit(self, query: Query) -> Tuple[QueryResponse, RateLimitInfo]:
+        """Executes query with retries and returns the response with rate limit info."""
+        return await self.inner.get_with_rate_limit(query)
+
+    def rate_limit_info(self) -> Optional[RateLimitInfo]:
+        """Get the most recently observed rate limit information. Returns None if no requests have been made yet."""
+        return self.inner.rate_limit_info()
+
+    async def wait_for_rate_limit(self) -> None:
+        """Wait until the current rate limit window resets. Returns immediately if no rate limit info observed or quota available."""
+        return await self.inner.wait_for_rate_limit()
 
     async def stream(self, query: Query, config: StreamConfig) -> QueryResponseStream:
         """Spawns task to execute query and return data via a channel."""

--- a/hypersync/__init__.py
+++ b/hypersync/__init__.py
@@ -774,8 +774,6 @@ class RateLimitInfo(object):
     reset_secs: Optional[int]
     # Budget consumed per request.
     cost: Optional[int]
-    # Seconds to wait before retrying (from retry-after header).
-    retry_after_secs: Optional[int]
     # Whether the rate limit quota has been exhausted.
     is_rate_limited: bool
     # Suggested number of seconds to wait before making another request.

--- a/hypersync/__init__.py
+++ b/hypersync/__init__.py
@@ -774,10 +774,6 @@ class RateLimitInfo(object):
     reset_secs: Optional[int]
     # Budget consumed per request.
     cost: Optional[int]
-    # Whether the rate limit quota has been exhausted.
-    is_rate_limited: bool
-    # Suggested number of seconds to wait before making another request.
-    suggested_wait_secs: Optional[int]
 
 
 class QueryResponse(object):

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,6 +76,8 @@ pub struct ClientConfig {
     pub retry_base_ms: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_ceiling_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proactive_rate_limit_sleep: Option<bool>,
 }
 
 impl ClientConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ use query::Query;
 use response::{
     convert_event_response, convert_response, ArrowStream, EventStream, QueryResponseStream,
 };
+use types::RateLimitInfo;
 
 #[pymodule]
 fn hypersync(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -34,6 +35,7 @@ fn hypersync(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ArrowStream>()?;
     m.add_class::<EventStream>()?;
     m.add_class::<QueryResponseStream>()?;
+    m.add_class::<RateLimitInfo>()?;
     m.add_function(wrap_pyfunction!(decode::signature_to_topic0, m)?)?;
 
     Ok(())
@@ -210,6 +212,45 @@ impl HypersyncClient {
             let res = response_to_pyarrow(res).context("convert response to pyarrow")?;
 
             Ok(res)
+        })
+    }
+
+    /// Get blockchain data for a single query, with rate limit info
+    pub fn get_with_rate_limit<'py>(
+        &'py self,
+        query: Query,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+
+        future_into_py(py, async move {
+            let query = query.try_convert().context("parse query")?;
+
+            let res = inner
+                .get_with_rate_limit(&query)
+                .await
+                .context("get with rate limit")?;
+
+            let response = convert_response(res.response).context("convert response")?;
+            let rate_limit: RateLimitInfo = res.rate_limit.into();
+
+            Ok((response, rate_limit))
+        })
+    }
+
+    /// Get the most recently observed rate limit information.
+    /// Returns None if no requests have been made yet.
+    pub fn rate_limit_info(&self) -> Option<RateLimitInfo> {
+        self.inner.rate_limit_info().map(|info| info.into())
+    }
+
+    /// Wait until the current rate limit window resets.
+    /// Returns immediately if no rate limit info observed or quota available.
+    pub fn wait_for_rate_limit<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        future_into_py(py, async move {
+            inner.wait_for_rate_limit().await;
+            Ok(())
         })
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -224,8 +224,6 @@ pub struct RateLimitInfo {
     pub reset_secs: Option<u64>,
     /// Budget consumed per request.
     pub cost: Option<u64>,
-    /// Seconds to wait before retrying (from retry-after header).
-    pub retry_after_secs: Option<u64>,
     /// Whether the rate limit quota has been exhausted.
     pub is_rate_limited: bool,
     /// Suggested number of seconds to wait before making another request.
@@ -239,7 +237,6 @@ impl From<hypersync_client::RateLimitInfo> for RateLimitInfo {
             remaining: info.remaining,
             reset_secs: info.reset_secs,
             cost: info.cost,
-            retry_after_secs: info.retry_after_secs,
             is_rate_limited: info.is_rate_limited(),
             suggested_wait_secs: info.suggested_wait_secs(),
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -224,10 +224,6 @@ pub struct RateLimitInfo {
     pub reset_secs: Option<u64>,
     /// Budget consumed per request.
     pub cost: Option<u64>,
-    /// Whether the rate limit quota has been exhausted.
-    pub is_rate_limited: bool,
-    /// Suggested number of seconds to wait before making another request.
-    pub suggested_wait_secs: Option<u64>,
 }
 
 impl From<hypersync_client::RateLimitInfo> for RateLimitInfo {
@@ -237,8 +233,6 @@ impl From<hypersync_client::RateLimitInfo> for RateLimitInfo {
             remaining: info.remaining,
             reset_secs: info.reset_secs,
             cost: info.cost,
-            is_rate_limited: info.is_rate_limited(),
-            suggested_wait_secs: info.suggested_wait_secs(),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -211,6 +211,41 @@ pub struct Trace {
     pub refund_address: Option<String>,
 }
 
+/// Rate limit information from server response headers.
+#[pyclass]
+#[pyo3(get_all)]
+#[derive(Clone)]
+pub struct RateLimitInfo {
+    /// Total request quota for the current window.
+    pub limit: Option<u64>,
+    /// Remaining budget in the current window.
+    pub remaining: Option<u64>,
+    /// Seconds until the rate limit window resets.
+    pub reset_secs: Option<u64>,
+    /// Budget consumed per request.
+    pub cost: Option<u64>,
+    /// Seconds to wait before retrying (from retry-after header).
+    pub retry_after_secs: Option<u64>,
+    /// Whether the rate limit quota has been exhausted.
+    pub is_rate_limited: bool,
+    /// Suggested number of seconds to wait before making another request.
+    pub suggested_wait_secs: Option<u64>,
+}
+
+impl From<hypersync_client::RateLimitInfo> for RateLimitInfo {
+    fn from(info: hypersync_client::RateLimitInfo) -> Self {
+        Self {
+            limit: info.limit,
+            remaining: info.remaining,
+            reset_secs: info.reset_secs,
+            cost: info.cost,
+            retry_after_secs: info.retry_after_secs,
+            is_rate_limited: info.is_rate_limited(),
+            suggested_wait_secs: info.suggested_wait_secs(),
+        }
+    }
+}
+
 /// Decoded EVM log
 #[pyclass]
 #[pyo3(get_all)]


### PR DESCRIPTION
## Summary
This PR adds comprehensive rate limit support to the Hypersync Python client, enabling users to access rate limit information from server responses and proactively manage rate limiting.

## Key Changes
- **New `RateLimitInfo` class**: Exposes rate limit details including limit, remaining quota, reset time, cost per request, retry-after header, and suggested wait time
- **New client methods**:
  - `get_with_rate_limit()`: Returns both query response and rate limit info as a tuple
  - `rate_limit_info()`: Retrieves the most recently observed rate limit information
  - `wait_for_rate_limit()`: Async method to wait until the rate limit window resets
- **New `ClientConfig` option**: `proactive_rate_limit_sleep` flag to enable proactive sleeping when rate limit is exhausted (default: True)
- **Updated dependencies**: Bumped `hypersync-client` from 1.0.2 to 1.1.0 to support new rate limit APIs
- **Version bump**: Updated package version from 0.10.0 to 0.11.0

## Implementation Details
- `RateLimitInfo` is a Rust struct with Python bindings that converts from the underlying `hypersync_client::RateLimitInfo` type
- The conversion includes computed fields like `is_rate_limited()` and `suggested_wait_secs()` from the client library
- All new async methods follow the existing pattern of using `future_into_py` for Python async compatibility
- The new config option is properly serialized with `skip_serializing_if` to maintain backward compatibility

https://claude.ai/code/session_012mwJv9YsuFKTvrgftATDB7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rate-limit API: view current rate-limit details, fetch responses together with rate-limit info, and wait for rate-limit reset.
  * Added `proactive_rate_limit_sleep` configuration option to influence client behavior when limits are reached.

* **Chores**
  * Bumped crate version to 1.0.0 and updated hypersync-client dependency to 1.1.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->