### PR TITLE
Upgrade to hypersync-client 1.3.0 (streaming v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [1.1.0] - 2026-06-08
+
+### Upgrade to hypersync-client-rust v1.3.0 (streaming engine v2)
+
+Upgrades the underlying Rust client to v1.3.0, which rewrites the streaming
+engine to size each request from observed byte-density and backfill truncation
+gaps in parallel. See the
+[Stream Config & Tuning guide](https://docs.envio.dev/docs/HyperSync/stream-config-tuning).
+
+### StreamConfig changes (breaking)
+
+- **Removed** `response_bytes_floor` and `response_bytes_ceiling`.
+- **Added** `response_bytes_target` (default `400000`) — each request is sized to
+  land near this response size.
+- **Added** `max_buffered_bytes` — cap on the undelivered reorder buffer (consumer
+  backpressure). Leave unset for an adaptive cap that grows with the largest
+  response seen.
+- `max_batch_size` is now an optional **no-cap**: leave it unset for no
+  blocks-per-request cap (over-shoot self-corrects via parallel backfill).
+
+Migration: if you set `response_bytes_floor` / `response_bytes_ceiling`, switch to
+a single `response_bytes_target`. Most users can drop these and keep the defaults.
+
+### Rate limit API (breaking)
+
+- `get_with_rate_limit` now returns `(response, rate_limit)` where `response` is
+  `None` when the request was rate limited (HTTP 429) — inspect `rate_limit` and
+  retry. Previously it always returned a response.
+
 ## [0.10.0] - 2026-03-14
 
 ### Upgrade to hypersync-client-rust v1.0.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,11 +1704,11 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1726,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "hypersync"
-version = "0.10.0"
+version = "1.1.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -1749,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "hypersync-client"
-version = "1.0.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce092a66f762855cb45d3ad071476ff42acc6fa299576d45828c02d75e4093c"
+checksum = "d01a41ac39a400475c05065f7a66f149b7108c1871d156238765ad12336d75ed"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -2394,6 +2404,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2973,6 +2989,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2989,7 +3006,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -3134,6 +3150,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,6 +3226,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3234,6 +3271,29 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4058,15 +4118,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 
 [lib]
@@ -20,7 +20,7 @@ serde = { version = "1", features = ["derive"] }
 alloy-json-abi = "1.1"
 alloy-dyn-abi = "1.1"
 alloy-primitives = "1.1"
-hypersync-client = "1.1.4"
+hypersync-client = "1.3.0"
 anyhow = "1"
 arrow = { version = "57", features = ["ffi"] }
 prefix-hex = "0.7"
@@ -29,3 +29,4 @@ faster-hex = "0.9"
 ruint = "1"
 num-bigint = "0.4"
 mimalloc = "0.1.43"
+

--- a/hypersync/__init__.py
+++ b/hypersync/__init__.py
@@ -691,11 +691,14 @@ class StreamConfig:
     event_signature: Optional[str] = None
     # Determines formatting of binary columns numbers into utf8 hex.
     hex_output: Optional[HexOutput] = None
-    # Maximum batch size that could be used during dynamic adjustment.
+    # Initial, deliberately-overestimated batch size used for the first wave of
+    # requests and as a fallback before any response density is measured. Default: 1000.
     batch_size: Optional[int] = None
-    # Maximum batch size that could be used during dynamic adjustment.
+    # Optional hard cap on the number of blocks per request. Leave unset (None) for
+    # no cap: an over-large request is truncated by the server and the remainder is
+    # backfilled in parallel, so overshoot self-corrects.
     max_batch_size: Optional[int] = None
-    # Minimum batch size that could be used during dynamic adjustment.
+    # Hard lower clamp on the projected block count, to avoid tiny ranges. Default: 200.
     min_batch_size: Optional[int] = None
     # Number of async threads that would be spawned to execute different block ranges of queries.
     concurrency: Optional[int] = None
@@ -707,10 +710,13 @@ class StreamConfig:
     max_num_logs: Optional[int] = None
     # Max number of traces to fetch in a single request.
     max_num_traces: Optional[int] = None
-    # Response bytes ceiling for dynamic batch size adjustment.
-    response_bytes_ceiling: Optional[int] = None
-    # Response bytes floor for dynamic batch size adjustment.
-    response_bytes_floor: Optional[int] = None
+    # Target response size in bytes. Each request's block span is projected from the
+    # most recently observed byte-density to aim each response at this size. Default: 400000.
+    response_bytes_target: Optional[int] = None
+    # Optional cap on the bytes of fetched-but-undelivered chunks held in the reorder
+    # buffer (consumer backpressure). Leave unset (None) for an adaptive cap that
+    # grows with the largest response seen.
+    max_buffered_bytes: Optional[int] = None
     # Stream data in reverse order.
     reverse: Optional[bool] = None
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,10 +28,14 @@ pub struct StreamConfig {
     pub max_num_logs: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_num_traces: Option<i64>,
+    /// Target response size in bytes; each request's block span is projected from
+    /// observed byte-density to aim each response at this size. Default: 400000.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub response_bytes_ceiling: Option<i64>,
+    pub response_bytes_target: Option<i64>,
+    /// Optional cap on undelivered reorder-buffer bytes (consumer backpressure).
+    /// Leave unset for an adaptive cap that grows with the largest response seen.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub response_bytes_floor: Option<i64>,
+    pub max_buffered_bytes: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reverse: Option<bool>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,8 +231,18 @@ impl HypersyncClient {
                 .await
                 .context("get with rate limit")?;
 
-            let response = convert_response(res.response).context("convert response")?;
-            let rate_limit: RateLimitInfo = res.rate_limit.into();
+            // On HTTP 429 the response is `None`; inspect rate_limit and retry later.
+            let (response, rate_limit) = match res {
+                hypersync_client::RateLimitResponse::Success {
+                    response,
+                    rate_limit,
+                } => (
+                    Some(convert_response(response).context("convert response")?),
+                    rate_limit,
+                ),
+                hypersync_client::RateLimitResponse::RateLimited(rate_limit) => (None, rate_limit),
+            };
+            let rate_limit: RateLimitInfo = rate_limit.into();
 
             Ok((response, rate_limit))
         })


### PR DESCRIPTION
Upgrades the core dep `hypersync-client` 1.1.4 → 1.3.0 (streaming engine v2) and adapts the API. Package 1.0.0 → 1.1.0.

## StreamConfig (breaking)
- Drop `response_bytes_floor` / `response_bytes_ceiling`.
- Add `response_bytes_target` (default 400000) and `max_buffered_bytes` (unset ⇒ adaptive reorder-buffer cap).
- `max_batch_size` stays optional and now means **no-cap** when unset (overshoot self-corrects via backfill).
- Updated `src/config.rs` and the Python `StreamConfig` dataclass in `hypersync/__init__.py`.

## Rate-limit API
- `get_with_rate_limit` adapts to the new `RateLimitResponse` enum: the response is `None` on HTTP 429 — inspect `rate_limit` and retry.

Verified with `cargo check` against published `hypersync-client` 1.3.0 (Cargo.lock updated). maturin wheel build happens in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## v1.1.0 Release

* **Configuration**
  * Redesigned stream configuration: new response sizing and buffering controls (response_bytes_target, max_buffered_bytes) and an optional no-cap max_batch_size for more flexible tuning.

* **Stability**
  * Improved rate-limit behavior: when requests are rate limited (HTTP 429) responses are now reported as absent while rate-limit info is still returned.

* **Chores**
  * Updated underlying client library to latest compatible version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->