### PR TITLE
ci: tag + GitHub Release on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,3 +141,51 @@ jobs:
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*
+
+  tag-and-release:
+    name: Tag and GitHub Release
+    runs-on: ubuntu-latest
+    # Only after the wheels are published to PyPI.
+    needs: [release]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Resolve version from Cargo.toml
+        id: ver
+        run: |
+          VERSION=$(grep -m1 '^version = ' Cargo.toml | sed -E 's/^version = "([^"]+)".*/\1/')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read version from Cargo.toml"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Create git tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.ver.outputs.tag }}"
+          VERSION="${{ steps.ver.outputs.version }}"
+          # Idempotent: skip if this version was already tagged/released (e.g. a
+          # re-run after `maturin upload --skip-existing` skipped an existing wheel).
+          if gh release view "$TAG" >/dev/null 2>&1 || git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Release/tag $TAG already exists — nothing to do."
+            exit 0
+          fi
+          # Use this version's CHANGELOG section as release notes, if present.
+          NOTES=$(awk -v ver="$VERSION" '
+            $0 ~ ("^## \\[" ver "\\]") {flag=1; next}
+            flag && /^## \[/ {exit}
+            flag {print}
+          ' CHANGELOG.md)
+          if [ -z "$(echo "$NOTES" | tr -d '[:space:]')" ]; then
+            NOTES="Release $TAG"
+          fi
+          # `gh release create` creates the git tag at the current commit and the release.
+          printf '%s\n' "$NOTES" | gh release create "$TAG" \
+            --target "$GITHUB_SHA" \
+            --title "$TAG" \
+            --notes-file -


### PR DESCRIPTION
Adds a **`tag-and-release`** job to the Publish workflow so a release cuts a git tag and a GitHub Release automatically.

## What it does
After the existing `release` job uploads wheels to PyPI, the new job:
1. Reads the version from `Cargo.toml` (the maturin `dynamic = ["version"]` source of truth).
2. Creates a **`v<version>` git tag** + **GitHub Release** with `gh release create` (creates both the tag and the release at the published commit).
3. Uses that version's section of `CHANGELOG.md` as the release notes (falls back to a default if absent).

## Notes
- **Idempotent:** skips cleanly if the tag/release already exists, matching `maturin upload --skip-existing` — so re-running Publish on an already-released version is a no-op.
- Adds job-scoped `permissions: contents: write` (the rest of the workflow stays `contents: read`).
- Convention is `v<version>` (the repo had no existing tags). Easy to change if you prefer a different format.

Trigger is unchanged (`workflow_dispatch`): bump `Cargo.toml`, run Publish, and you get PyPI + tag + release in one flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated release workflow to create GitHub releases and version tags after package uploads, with release notes automatically extracted from the project changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->