### PR TITLE
Set a Python-specific user agent (hscp/<version>)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.2.0] - 2026-06-08
+
+### Python-specific user agent
+
+The client now identifies itself to the server as `hscp/<version>`
+(hypersync-client-python) instead of the core Rust client's default
+`hscr/<version>`, so traffic is attributed to the Python client and its
+release version.
+
 ## [1.1.0] - 2026-06-08
 
 ### Upgrade to hypersync-client-rust v1.3.0 (streaming engine v2)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "hypersync"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,16 @@ impl HypersyncClient {
 
         let config = config.try_convert().context("parse config")?;
 
+        // Identify this client (and its version) to the server. `hscp` =
+        // hypersync-client-python; the version is this package's version, which
+        // maturin derives from Cargo.toml's [package] version.
+        let user_agent = format!("hscp/{}", env!("CARGO_PKG_VERSION"));
+
         Ok(HypersyncClient {
-            inner: Arc::new(hypersync_client::Client::new(config).context("create client")?),
+            inner: Arc::new(
+                hypersync_client::Client::new_with_agent(config, user_agent)
+                    .context("create client")?,
+            ),
         })
     }
 


### PR DESCRIPTION
The Python client constructs the core client via `Client::new`, so requests go out with the core's default user agent `hscr/<rust-version>` (rust client). This switches to `Client::new_with_agent` with **`hscp/<version>`** (hscp = hypersync-client-python), where the version is this package's version (maturin derives it from `Cargo.toml`).

Matches what the Rust (`hscr/`) and Node (`hscn/`) clients do, so the server can attribute traffic to the Python client and its actual release version.

Verified with `cargo check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Network requests now include an explicit client identifier with version to improve tracking and diagnostics.
* **Documentation**
  * Release notes updated for version 1.2.0 to reflect the new client identification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->