### PR TITLE
Upgrade to hypersync-client 1.4.1 and release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.2.1] - 2026-09-08
+
+### Upgrade to hypersync-client-rust v1.4.1
+
+Upgrades the underlying Rust client to v1.4.1. Passing `hex_output=PREFIXED`
+or `NON_PREFIXED` to `collect`, `collect_events`, `stream` or `stream_events`
+now raises a clear error explaining that `hex_output` only applies to the
+arrow and parquet methods, instead of failing inside the arrow decoder with
+`column address expected to be of type ... Binary but found Utf8`. Fixes #64.
+
 ## [1.2.0] - 2026-06-08
 
 ### Python-specific user agent

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "hypersync"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -1759,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "hypersync-client"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a41ac39a400475c05065f7a66f149b7108c1871d156238765ad12336d75ed"
+checksum = "dca9471910111c53476ea3be6840881e502ad8f788a87c4779d7f6c319f995a2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [lib]
@@ -20,7 +20,7 @@ serde = { version = "1", features = ["derive"] }
 alloy-json-abi = "1.1"
 alloy-dyn-abi = "1.1"
 alloy-primitives = "1.1"
-hypersync-client = "1.3.0"
+hypersync-client = "1.4.1"
 anyhow = "1"
 arrow = { version = "57", features = ["ffi"] }
 prefix-hex = "0.7"


### PR DESCRIPTION
Bumps the underlying Rust client to 1.4.1 and the package version to 1.2.1.

hypersync-client 1.4.1 makes `collect`, `collect_events`, `stream` and `stream_events` reject `hex_output=PREFIXED` / `NON_PREFIXED` with a clear error instead of failing inside the arrow decoder. Fixes #64 / HOS-2200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KD1app4Synx92e36NZJ3Ww


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added clearer error messages when `hex_output` is used with unsupported collection or streaming methods.
  - Prevented confusing decoder errors in these cases.

- **Documentation**
  - Added release notes for version 1.2.1, including details about the improved error handling.

- **Chores**
  - Updated the package release to version 1.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->